### PR TITLE
Move Guava dependency from "server" to "common"

### DIFF
--- a/src/main/resources/fabric-installer.json
+++ b/src/main/resources/fabric-installer.json
@@ -48,14 +48,14 @@
       {
         "name": "org.ow2.asm:asm-util:9.0",
         "url": "https://maven.fabricmc.net/"
-      }
-    ],
-    "server": [
+      },
       {
-        "_comment": "jimfs in fabric-server-launch requires guava on the system classloader",
         "name": "com.google.guava:guava:21.0",
         "url": "https://maven.fabricmc.net/"
       }
+    ],
+    "server": [
+
     ]
   },
   "mainClass": {

--- a/src/main/resources/fabric-installer.launchwrapper.json
+++ b/src/main/resources/fabric-installer.launchwrapper.json
@@ -51,14 +51,14 @@
       {
         "name": "org.ow2.asm:asm-util:9.0",
         "url": "https://maven.fabricmc.net/"
-      }
-    ],
-    "server": [
+      },
       {
-        "_comment": "jimfs in fabric-server-launch requires guava on the system classloader",
         "name": "com.google.guava:guava:21.0",
         "url": "https://maven.fabricmc.net/"
       }
+    ],
+    "server": [
+
     ]
   },
   "mainClass": "net.minecraft.launchwrapper.Launch",


### PR DESCRIPTION
Guava is bundled with Minecraft, but on some versions (including 1.7.10) the bundled copy is too old. Explicitly installing Guava on the client is required for automated tools like MultiMC to work properly.